### PR TITLE
Add concept image placeholders

### DIFF
--- a/assets/img/cleaning-deep-cleaning.svg
+++ b/assets/img/cleaning-deep-cleaning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Deep Cleaning</text>
+</svg>

--- a/assets/img/cleaning-floor-care.svg
+++ b/assets/img/cleaning-floor-care.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Floor Care</text>
+</svg>

--- a/assets/img/cleaning-glass-facade.svg
+++ b/assets/img/cleaning-glass-facade.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Glass Facade</text>
+</svg>

--- a/assets/img/cleaning-harian.svg
+++ b/assets/img/cleaning-harian.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Harian</text>
+</svg>

--- a/assets/img/cleaning-housekeeping-rs.svg
+++ b/assets/img/cleaning-housekeeping-rs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Housekeeping RS</text>
+</svg>

--- a/assets/img/cleaning-industrial-cleaning.svg
+++ b/assets/img/cleaning-industrial-cleaning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#059669"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Industrial Cleaning</text>
+</svg>

--- a/assets/img/client1.svg
+++ b/assets/img/client1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#6b7280"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Client 1</text>
+</svg>

--- a/assets/img/client2.svg
+++ b/assets/img/client2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#6b7280"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Client 2</text>
+</svg>

--- a/assets/img/client3.svg
+++ b/assets/img/client3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#6b7280"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Client 3</text>
+</svg>

--- a/assets/img/client4.svg
+++ b/assets/img/client4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#6b7280"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Client 4</text>
+</svg>

--- a/assets/img/client5.svg
+++ b/assets/img/client5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#6b7280"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Client 5</text>
+</svg>

--- a/assets/img/portfolio1.svg
+++ b/assets/img/portfolio1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 1</text>
+</svg>

--- a/assets/img/portfolio2.svg
+++ b/assets/img/portfolio2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 2</text>
+</svg>

--- a/assets/img/portfolio3.svg
+++ b/assets/img/portfolio3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 3</text>
+</svg>

--- a/assets/img/portfolio4.svg
+++ b/assets/img/portfolio4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 4</text>
+</svg>

--- a/assets/img/portfolio5.svg
+++ b/assets/img/portfolio5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 5</text>
+</svg>

--- a/assets/img/portfolio6.svg
+++ b/assets/img/portfolio6.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#10b981"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Project 6</text>
+</svg>

--- a/assets/img/security-access-control.svg
+++ b/assets/img/security-access-control.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Access Control</text>
+</svg>

--- a/assets/img/security-cctv-monitoring.svg
+++ b/assets/img/security-cctv-monitoring.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">CCTV Monitoring</text>
+</svg>

--- a/assets/img/security-event-security.svg
+++ b/assets/img/security-event-security.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Event Security</text>
+</svg>

--- a/assets/img/security-patrol.svg
+++ b/assets/img/security-patrol.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Patrol</text>
+</svg>

--- a/assets/img/security-security-audit.svg
+++ b/assets/img/security-security-audit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Security Audit</text>
+</svg>

--- a/assets/img/security-unarmed-guard.svg
+++ b/assets/img/security-unarmed-guard.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#0369a1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">Unarmed Guard</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -97,22 +97,22 @@
     <div class="tab-content pt-4" id="serviceTabContent">
       <div class="tab-pane fade show active" id="cleaning" role="tabpanel">
         <div class="row row-cols-1 row-cols-md-3 g-4">
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Harian</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Deep Cleaning</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Glass Facade</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Floor Care</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Housekeeping RS</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Industrial Cleaning</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-harian.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Harian</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-deep-cleaning.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Deep Cleaning</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-glass-facade.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Glass Facade</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-floor-care.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Floor Care</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-housekeeping-rs.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Housekeeping RS</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/cleaning-industrial-cleaning.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Industrial Cleaning</h5></div></div></div>
         </div>
       </div>
       <div class="tab-pane fade" id="security" role="tabpanel">
         <div class="row row-cols-1 row-cols-md-3 g-4">
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Unarmed Guard</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Access Control</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Patrol</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">CCTV Monitoring</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Event Security</h5></div></div></div>
-          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Security Audit</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-unarmed-guard.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Unarmed Guard</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-access-control.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Access Control</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-patrol.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Patrol</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-cctv-monitoring.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">CCTV Monitoring</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-event-security.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Event Security</h5></div></div></div>
+          <div class="col"><div class="card h-100" data-aos="fade-up"><img src="assets/img/security-security-audit.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Security Audit</h5></div></div></div>
         </div>
       </div>
     </div>
@@ -121,11 +121,11 @@
 
 <section class="py-5 bg-light">
   <div class="logo-marquee d-flex align-items-center">
-    <img src="assets/img/placeholder.svg" alt="Client 1" loading="lazy">
-    <img src="assets/img/placeholder.svg" alt="Client 2" loading="lazy">
-    <img src="assets/img/placeholder.svg" alt="Client 3" loading="lazy">
-    <img src="assets/img/placeholder.svg" alt="Client 4" loading="lazy">
-    <img src="assets/img/placeholder.svg" alt="Client 5" loading="lazy">
+    <img src="assets/img/client1.svg" alt="Client 1" loading="lazy">
+    <img src="assets/img/client2.svg" alt="Client 2" loading="lazy">
+    <img src="assets/img/client3.svg" alt="Client 3" loading="lazy">
+    <img src="assets/img/client4.svg" alt="Client 4" loading="lazy">
+    <img src="assets/img/client5.svg" alt="Client 5" loading="lazy">
   </div>
 </section>
 
@@ -159,12 +159,12 @@
   <div class="container">
     <h2 class="text-center mb-4">Portfolio</h2>
     <div class="masonry">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
+      <img src="assets/img/portfolio1.svg" alt="Project 1" loading="lazy">
+      <img src="assets/img/portfolio2.svg" alt="Project 2" loading="lazy">
+      <img src="assets/img/portfolio3.svg" alt="Project 3" loading="lazy">
+      <img src="assets/img/portfolio4.svg" alt="Project 4" loading="lazy">
+      <img src="assets/img/portfolio5.svg" alt="Project 5" loading="lazy">
+      <img src="assets/img/portfolio6.svg" alt="Project 6" loading="lazy">
     </div>
   </div>
 </section>

--- a/layanan.html
+++ b/layanan.html
@@ -58,22 +58,22 @@
     <div class="tab-content pt-4" id="serviceTabContent">
       <div class="tab-pane fade show active" id="cleaning" role="tabpanel">
         <div class="row row-cols-1 row-cols-md-3 g-4">
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Harian</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Deep Cleaning</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Glass Facade</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Floor Care</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Housekeeping RS</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Industrial Cleaning</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-harian.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Harian</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-deep-cleaning.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Deep Cleaning</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-glass-facade.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Glass Facade</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-floor-care.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Floor Care</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-housekeeping-rs.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Housekeeping RS</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/cleaning-industrial-cleaning.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Industrial Cleaning</h5></div></div></div>
         </div>
       </div>
       <div class="tab-pane fade" id="security" role="tabpanel">
         <div class="row row-cols-1 row-cols-md-3 g-4">
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Unarmed Guard</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Access Control</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Patrol</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">CCTV Monitoring</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Event Security</h5></div></div></div>
-          <div class="col"><div class="card h-100"><img src="assets/img/placeholder.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Security Audit</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-unarmed-guard.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Unarmed Guard</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-access-control.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Access Control</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-patrol.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Patrol</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-cctv-monitoring.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">CCTV Monitoring</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-event-security.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Event Security</h5></div></div></div>
+          <div class="col"><div class="card h-100"><img src="assets/img/security-security-audit.svg" class="card-img-top" alt="" loading="lazy"><div class="card-body"><h5 class="card-title">Security Audit</h5></div></div></div>
         </div>
       </div>
     </div>

--- a/portfolio.html
+++ b/portfolio.html
@@ -48,12 +48,12 @@
 <section class="py-5 bg-light">
   <div class="container">
     <div class="masonry">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
-      <img src="assets/img/placeholder.svg" alt="Project" loading="lazy">
+      <img src="assets/img/portfolio1.svg" alt="Project 1" loading="lazy">
+      <img src="assets/img/portfolio2.svg" alt="Project 2" loading="lazy">
+      <img src="assets/img/portfolio3.svg" alt="Project 3" loading="lazy">
+      <img src="assets/img/portfolio4.svg" alt="Project 4" loading="lazy">
+      <img src="assets/img/portfolio5.svg" alt="Project 5" loading="lazy">
+      <img src="assets/img/portfolio6.svg" alt="Project 6" loading="lazy">
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace generic placeholders with concept-specific SVGs for services, clients, and portfolio items
- include generated SVG placeholders for all sections

## Testing
- `python -m py_compile scripts/scrape_assets.py`
- `pip install pillow` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f015da9c883319d83566b529a8804